### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "java10"
+run = "javac ConwayLife.java"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # CodingWars
+ [![Run on Repl.it](https://repl.it/badge/github/Domchap90/CodingWars)](https://repl.it/github/Domchap90/CodingWars)
 My Solutions to Coding Wars problems with appropriate unit tests.
 https://www.codewars.com/


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@domchap90/CodingWars-1).